### PR TITLE
task.sleep accepts int or float

### DIFF
--- a/apps/pyscript_autocomplete/pyscript_builtins.py
+++ b/apps/pyscript_autocomplete/pyscript_builtins.py
@@ -170,7 +170,7 @@ class task:
         ...
 
     @staticmethod
-    def sleep(seconds: int):
+    def sleep(seconds: Union[int, float]):
         """
         https://hacs-pyscript.readthedocs.io/en/stable/reference.html#task-sleep
         """


### PR DESCRIPTION
fixes parameter type highlighting for task.sleep according to https://hacs-pyscript.readthedocs.io/en/stable/reference.html#task-sleep and https://github.com/custom-components/pyscript/blob/master/custom_components/pyscript/function.py#L206